### PR TITLE
Revamp landing page to showcase Google Docs document

### DIFF
--- a/app/home.go
+++ b/app/home.go
@@ -3,93 +3,25 @@ package app
 import (
 	"encoding/json"
 	"fmt"
-	"io"
-	"log"
-	"net/http"
 	"os"
 
 	"asta-karya/models"
 )
 
-func FetchGoogleSheetData() (string, error) {
-	apiURL := "https://sheets.googleapis.com/v4/spreadsheets/1V8c2Zx4j8Lf6XgD4g3eskE-QCw3e5S8qPaBIJrsYlPY/values/Sheet1!B2?key=AIzaSyBof-SD7PX06Fpx_uZbZhpI5w4S8iAXqm4"
-
-	resp, err := http.Get(apiURL)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("API request failed with status: %d", resp.StatusCode)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	var sheetData models.GoogleSheetResponse
-	err = json.Unmarshal(body, &sheetData)
-	if err != nil {
-		return "", err
-	}
-
-	if len(sheetData.Values) > 0 && len(sheetData.Values[0]) > 0 {
-		return sheetData.Values[0][0], nil
-	}
-
-	return "No Data", nil
-}
-
-func UpdateJSONFile(lang string, newMapContent string) error {
-	filePath := fmt.Sprintf("locales/home_%s.json", lang)
-
-	jsonData, err := os.ReadFile(filePath)
-	if err != nil {
-		return err
-	}
-
-	var sheet models.Home
-	err = json.Unmarshal(jsonData, &sheet)
-	if err != nil {
-		return err
-	}
-
-	sheet.MapContent = newMapContent
-
-	updatedJSON, err := json.MarshalIndent(sheet, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	return os.WriteFile(filePath, updatedJSON, 0644)
-}
-
+// LoadJSONFile reads the localized home configuration file for the given language
+// and returns the structured content for the landing page.
 func LoadJSONFile(lang string) (*models.Home, error) {
-	homeContent, err := FetchGoogleSheetData()
-	if err != nil {
-		log.Println("Error fetching Google Sheets data:", err)
-		homeContent = "Error fetching data"
-	} else {
-		err = UpdateJSONFile(lang, homeContent)
-		if err != nil {
-			log.Println("Error updating JSON file:", err)
-		}
-	}
-
 	filePath := fmt.Sprintf("locales/home_%s.json", lang)
 
-	jsonData, err := os.ReadFile(filePath)
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
 
-	var sheet models.Home
-	err = json.Unmarshal(jsonData, &sheet)
-	if err != nil {
+	var content models.Home
+	if err := json.Unmarshal(data, &content); err != nil {
 		return nil, err
 	}
 
-	return &sheet, nil
+	return &content, nil
 }

--- a/locales/header_id.json
+++ b/locales/header_id.json
@@ -1,10 +1,8 @@
 {
-    "title": "LPK Asta Karya - Live Work and Learn in Japan",
+    "title": "LPK Asta Karya - Dokumentasi Resmi",
     "home": "Beranda",
-    "about": "Ini Kami",
-    "program": "Program",
-    "training": "Pelatihan",
-    "media": "Media",
-    "galery": "Galery",
+    "highlights": "Sorotan",
+    "document": "Dokumen",
+    "galery": "Galeri",
     "change_language": "日本語"
 }

--- a/locales/header_jp.json
+++ b/locales/header_jp.json
@@ -1,10 +1,8 @@
 {
-    "title": "LPK Asta Karya - 日本での生活、仕事、学習",
+    "title": "LPK Asta Karya - 公式ドキュメント",
     "home": "ホーム",
-    "about": "私たちについて",
-    "program": "プログラム",
-    "training": "トレーニング",
-    "media": "メディア",
-    "galery": "メディ",
+    "highlights": "ハイライト",
+    "document": "ドキュメント",
+    "galery": "ギャラリー",
     "change_language": "Bahasa Indonesia"
 }

--- a/locales/home_id.json
+++ b/locales/home_id.json
@@ -1,10 +1,26 @@
 {
-  "slide1H1": "Sending Organization",
-  "slide1H3": "Lembaga Pelatihan Kerja Asta Karya adalah lembaga resmi dan terakreditasi sebagai Sending Organization ke Jepang. Kami menyalurkan siswa-siswi kami sebagai tenaga magang yang akan ditempatkan di Jepang dengan durasi kontrak yang bervariatif.",
-  "slide2H1": "Program",
-  "slide2H2": "Jenis kerja yang akan diambil siswa cukup beragam dan durasi kontrak selama menjadi pemagangan pun bervariasi. Ada banyak hal yang siswa harus pahami mengenai program magang ini agar tidak salah langkah dalam mengambil keputusan baik dalam jenis kerja ataupun dalam jenis visa.",
-  "slide3H1": "Training Center",
-  "slide3H2": "Magang akan membawa Peserta keluar dari zona nyaman mereka, menempuh perjalanan dan pengalaman hidup di Jepang akan mengubah perspektif hidup mereka, membawa pengalaman baru diluar CV mereka. Maka dari itu kami bekali peserta dengan dasar-dasar mental yang kuat!",
-  "mapHeader": "Total Siswa",
-  "mapContent": "5000"
+  "heroTitle": "Dokumentasi Resmi LPK Asta Karya",
+  "heroSubtitle": "Seluruh informasi terbaru kami kini terpusat dalam dokumen Google yang selalu diperbarui oleh tim LPK Asta Karya.",
+  "heroButtonLabel": "Buka Dokumen Lengkap",
+  "heroSupport": "Gunakan tombol di atas untuk membaca versi penuh dan menyalin tautan dokumen jika dibutuhkan.",
+  "docUrl": "https://docs.google.com/document/d/1kqhuIBQGB0uZyoScUHngD6b-8LNZXQ483dYiOn-6AnA/edit?usp=drivesdk",
+  "docEmbedUrl": "https://docs.google.com/document/d/1kqhuIBQGB0uZyoScUHngD6b-8LNZXQ483dYiOn-6AnA/preview",
+  "docNote": "Apabila pratinjau tidak muncul, klik tombol \"Buka Dokumen Lengkap\" atau salin tautannya secara manual.",
+  "highlights": [
+    {
+      "icon": "fa-refresh",
+      "title": "Konten Selalu Terkini",
+      "description": "Perubahan apapun pada dokumen Google akan langsung tercermin di halaman ini."
+    },
+    {
+      "icon": "fa-file-text-o",
+      "title": "Satu Sumber Terpadu",
+      "description": "Seluruh informasi profil, program, dan persyaratan dipusatkan dalam satu dokumen resmi."
+    },
+    {
+      "icon": "fa-external-link",
+      "title": "Mudah Diakses",
+      "description": "Buka dokumen di tab baru untuk pengalaman membaca penuh serta opsi unduh jika diperlukan."
+    }
+  ]
 }

--- a/locales/home_jp.json
+++ b/locales/home_jp.json
@@ -1,10 +1,26 @@
 {
-  "slide1H1": "送信組織",
-  "slide1H3": "Asta Karya Job Training Institute は、日本への派遣機関として認定された公式機関です。当校では、学生をインターンとして派遣し、さまざまな契約期間で日本に派遣します。",
-  "slide2H1": "プログラム",
-  "slide2H2": "学生が従事する仕事の種類は非常に多様であり、インターンシップ中の契約期間も異なります。仕事の種類やビザの種類に関して誤った決定をしないように、学生はこのインターンシップ プログラムについて理解しなければならないことがたくさんあります。",
-  "slide3H1": "トレーニングセンター",
-  "slide3H2": "インターンシップは参加者を快適な環境から連れ出し、日本を旅行し、日本での生活を体験することで人生観を変え、履歴書に記された以上の新しい経験をもたらします。そのため、参加者に強固な精神的基盤を提供します。",
-  "mapHeader": "生徒総数",
-  "mapContent": "5000"
+  "heroTitle": "LPK Asta Karya 公式ドキュメント",
+  "heroSubtitle": "最新の情報は常に更新される Google ドキュメントに集約されています。",
+  "heroButtonLabel": "ドキュメントを開く",
+  "heroSupport": "上のボタンから完全版を表示し、必要であればリンクをコピーしてください。",
+  "docUrl": "https://docs.google.com/document/d/1kqhuIBQGB0uZyoScUHngD6b-8LNZXQ483dYiOn-6AnA/edit?usp=drivesdk",
+  "docEmbedUrl": "https://docs.google.com/document/d/1kqhuIBQGB0uZyoScUHngD6b-8LNZXQ483dYiOn-6AnA/preview",
+  "docNote": "プレビューが表示されない場合は「ドキュメントを開く」をクリックするか、リンクをコピーしてください。",
+  "highlights": [
+    {
+      "icon": "fa-refresh",
+      "title": "常に最新",
+      "description": "Google ドキュメントの更新内容がこのページにも即時反映されます。"
+    },
+    {
+      "icon": "fa-file-text-o",
+      "title": "情報を一元化",
+      "description": "プロフィール、プログラム、要件などを公式ドキュメント一つにまとめました。"
+    },
+    {
+      "icon": "fa-external-link",
+      "title": "簡単アクセス",
+      "description": "新しいタブで開いて全文表示やダウンロードを行うことができます。"
+    }
+  ]
 }

--- a/main.go
+++ b/main.go
@@ -14,13 +14,11 @@ import (
 )
 
 type Header struct {
-	Title    string `json:"title"`
-	Home     string `json:"home"`
-	About    string `json:"about"`
-	Program  string `json:"program"`
-	Training string `json:"training"`
-	Media    string `json:"media"`
-	Galery   string `json:"galery"`
+	Title      string `json:"title"`
+	Home       string `json:"home"`
+	Highlights string `json:"highlights"`
+	Document   string `json:"document"`
+	Galery     string `json:"galery"`
 }
 
 func loadJSONFile(filePath string, target interface{}) error {

--- a/models/home.go
+++ b/models/home.go
@@ -1,18 +1,20 @@
 package models
 
+// Home represents the localized content that powers the landing page.
 type Home struct {
-	Home1H1    string `json:"slide1H1"`
-	Home1H3    string `json:"slide1H3"`
-	Home2H1    string `json:"slide2H1"`
-	Home2H3    string `json:"slide2H2"`
-	Home3H1    string `json:"slide3H1"`
-	Home3H3    string `json:"slide3H2"`
-	MapHeader  string `json:"mapHeader"`
-	MapContent string `json:"mapContent"`
+	HeroTitle       string      `json:"heroTitle"`
+	HeroSubtitle    string      `json:"heroSubtitle"`
+	HeroButtonLabel string      `json:"heroButtonLabel"`
+	HeroSupport     string      `json:"heroSupport"`
+	DocURL          string      `json:"docUrl"`
+	DocEmbedURL     string      `json:"docEmbedUrl"`
+	DocNote         string      `json:"docNote"`
+	Highlights      []Highlight `json:"highlights"`
 }
 
-type GoogleSheetResponse struct {
-	Range          string     `json:"range"`
-	MajorDimension string     `json:"majorDimension"`
-	Values         [][]string `json:"values"`
+// Highlight represents a short value proposition displayed beneath the hero section.
+type Highlight struct {
+	Icon        string `json:"icon"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
 }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,0 +1,404 @@
+:root {
+    --primary: #1b6ef3;
+    --primary-dark: #124db8;
+    --accent: #ffb74d;
+    --background: #f5f7fb;
+    --text-color: #1f2933;
+    --muted: #6c7a89;
+    --card-shadow: 0 20px 45px rgba(15, 34, 58, 0.12);
+}
+
+html, body {
+    height: 100%;
+}
+
+body.site {
+    font-family: 'Poppins', sans-serif;
+    color: var(--text-color);
+    background: var(--background);
+    line-height: 1.7;
+    overflow-x: hidden;
+}
+
+a {
+    color: var(--primary);
+}
+
+a:hover,
+a:focus {
+    color: var(--primary-dark);
+    text-decoration: none;
+}
+
+.custom-navbar {
+    background: rgba(255, 255, 255, 0.95);
+    border: none;
+    box-shadow: 0 10px 30px rgba(27, 110, 243, 0.08);
+    transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.custom-navbar.navbar-solid {
+    background: #ffffff;
+    box-shadow: 0 14px 40px rgba(15, 34, 58, 0.12);
+}
+
+.custom-navbar .navbar-brand {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-weight: 600;
+    color: var(--text-color);
+}
+
+.navbar-brand-logo {
+    max-height: 58px;
+}
+
+.navbar-brand-text {
+    font-size: 1.2rem;
+    letter-spacing: 0.02em;
+}
+
+.custom-navbar .navbar-nav > li > a {
+    color: var(--muted);
+    font-weight: 500;
+    transition: color 0.2s ease;
+    padding: 18px 16px;
+}
+
+.custom-navbar .navbar-nav > li > a:hover,
+.custom-navbar .navbar-nav > li > a:focus {
+    color: var(--primary);
+}
+
+.custom-navbar .dropdown-menu {
+    border-radius: 12px;
+    border: none;
+    box-shadow: var(--card-shadow);
+    margin-top: 12px;
+}
+
+.site-header .navbar-toggle .icon-bar {
+    background: var(--text-color);
+}
+
+.hero-section {
+    position: relative;
+    padding: 160px 0 120px;
+    background: linear-gradient(135deg, rgba(27, 110, 243, 0.08), rgba(255, 255, 255, 0));
+}
+
+.hero-section .row {
+    display: flex;
+    align-items: center;
+    gap: 30px;
+}
+
+.hero-title {
+    font-size: 2.8rem;
+    font-weight: 700;
+    margin-bottom: 20px;
+    color: var(--text-color);
+}
+
+.hero-subtitle {
+    font-size: 1.1rem;
+    color: var(--muted);
+    max-width: 520px;
+}
+
+.hero-actions {
+    margin-top: 28px;
+}
+
+.hero-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    background: var(--primary);
+    border: none;
+    border-radius: 14px;
+    padding: 14px 26px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    box-shadow: 0 15px 35px rgba(27, 110, 243, 0.25);
+}
+
+.hero-btn:hover,
+.hero-btn:focus {
+    background: var(--primary-dark);
+    box-shadow: 0 18px 36px rgba(18, 77, 184, 0.32);
+}
+
+.hero-support {
+    margin-top: 16px;
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.hero-illustration {
+    position: relative;
+    min-height: 260px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.hero-blob {
+    position: absolute;
+    width: 320px;
+    height: 320px;
+    background: radial-gradient(circle at 30% 30%, rgba(27, 110, 243, 0.35), rgba(27, 110, 243, 0));
+    filter: blur(0.2px);
+    border-radius: 50%;
+    transform: rotate(12deg);
+    animation: float 6s ease-in-out infinite;
+}
+
+@keyframes float {
+    0%, 100% {
+        transform: translateY(0) scale(1);
+    }
+    50% {
+        transform: translateY(-12px) scale(1.03);
+    }
+}
+
+.hero-card {
+    position: relative;
+    background: #ffffff;
+    border-radius: 24px;
+    padding: 32px;
+    box-shadow: var(--card-shadow);
+    max-width: 360px;
+    z-index: 2;
+}
+
+.hero-card-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 14px;
+    border-radius: 999px;
+    background: rgba(27, 110, 243, 0.12);
+    color: var(--primary-dark);
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.hero-card-title {
+    font-size: 1.4rem;
+    margin: 18px 0 12px;
+    color: var(--text-color);
+}
+
+.hero-card-text {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.section-heading {
+    margin-bottom: 48px;
+}
+
+.section-title {
+    font-size: 2rem;
+    font-weight: 600;
+    margin-bottom: 12px;
+}
+
+.section-subtitle {
+    color: var(--muted);
+    max-width: 640px;
+    margin: 0 auto;
+}
+
+.highlights-section {
+    padding: 120px 0;
+}
+
+.highlight-card {
+    background: #ffffff;
+    border-radius: 20px;
+    padding: 32px;
+    margin-bottom: 30px;
+    box-shadow: var(--card-shadow);
+    height: 100%;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.highlight-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 26px 50px rgba(27, 110, 243, 0.18);
+}
+
+.highlight-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 14px;
+    background: rgba(27, 110, 243, 0.12);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--primary);
+    font-size: 1.25rem;
+    margin-bottom: 18px;
+}
+
+.highlight-title {
+    font-size: 1.2rem;
+    font-weight: 600;
+    margin-bottom: 12px;
+}
+
+.highlight-description {
+    color: var(--muted);
+    margin: 0;
+}
+
+.document-preview {
+    padding: 80px 0 120px;
+}
+
+.preview-card {
+    background: #ffffff;
+    border-radius: 28px;
+    box-shadow: var(--card-shadow);
+    padding: 40px;
+}
+
+.preview-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    margin-bottom: 30px;
+}
+
+.preview-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 14px;
+    border-radius: 999px;
+    background: rgba(255, 183, 77, 0.18);
+    color: #e57b00;
+    font-weight: 600;
+}
+
+.btn.btn-outline {
+    border: 1px solid var(--primary);
+    color: var(--primary);
+    border-radius: 14px;
+    padding: 12px 24px;
+    font-weight: 600;
+    background: transparent;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.btn.btn-outline:hover,
+.btn.btn-outline:focus {
+    background: var(--primary);
+    color: #ffffff;
+}
+
+.preview-frame {
+    border-radius: 20px;
+    overflow: hidden;
+    box-shadow: inset 0 0 0 1px rgba(27, 110, 243, 0.08);
+}
+
+.preview-frame iframe {
+    width: 100%;
+    min-height: 640px;
+    border: none;
+    background: #ffffff;
+}
+
+.preview-note {
+    margin-top: 20px;
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.preview-empty {
+    padding: 40px;
+    border-radius: 18px;
+    background: rgba(27, 110, 243, 0.08);
+    text-align: center;
+    color: var(--muted);
+}
+
+.site-footer {
+    background: #0f172a;
+    color: rgba(255, 255, 255, 0.72);
+    padding: 40px 0;
+    text-align: center;
+}
+
+.footer-text {
+    margin-bottom: 12px;
+}
+
+.footer-links {
+    display: flex;
+    justify-content: center;
+    gap: 24px;
+    flex-wrap: wrap;
+}
+
+.footer-link {
+    color: rgba(255, 255, 255, 0.72);
+    transition: color 0.2s ease;
+}
+
+.footer-link:hover,
+.footer-link:focus {
+    color: #ffffff;
+}
+
+@media (max-width: 991px) {
+    .hero-section {
+        padding-top: 140px;
+    }
+
+    .hero-title {
+        font-size: 2.2rem;
+    }
+
+    .hero-section .row {
+        flex-direction: column;
+    }
+
+    .hero-illustration {
+        margin-top: 40px;
+    }
+}
+
+@media (max-width: 767px) {
+    .custom-navbar .navbar-nav > li > a {
+        padding: 12px 16px;
+    }
+
+    .preview-frame iframe {
+        min-height: 520px;
+    }
+}
+
+@media (max-width: 480px) {
+    .hero-card {
+        padding: 24px;
+    }
+
+    .highlight-card {
+        padding: 24px;
+    }
+
+    .preview-card {
+        padding: 28px 20px;
+    }
+}

--- a/static/js/custom.js
+++ b/static/js/custom.js
@@ -1,81 +1,36 @@
-
-// preloader
-$(window).load(function(){
-    $('.preloader').fadeOut(1000); // set duration in brackets    
+// Preloader
+$(window).on('load', function () {
+    $('.preloader').fadeOut(800);
 });
 
-$(document).ready(function() {
-
-	/* Hide mobile menu after clicking on a link
-    -----------------------------------------------*/
-    $('.navbar-collapse a').click(function(){
-        $(".navbar-collapse").collapse('hide');
+$(document).ready(function () {
+    // Hide mobile menu after clicking on a link
+    $('.navbar-collapse a').on('click', function () {
+        $('.navbar-collapse').collapse('hide');
     });
 
-    // jQuery to collapse the navbar on scroll //
-	$(window).scroll(function() {
-	    if ($(".navbar").offset().top > 50) {
-	        $(".navbar-fixed-top").addClass("top-nav-collapse");
-	    } else {
-	        $(".navbar-fixed-top").removeClass("top-nav-collapse");
-	    }
-	});
-	
-	/* FlexSlider
-	-----------------------------*/ 
-  	$('.flexslider').flexslider({
-      animation: "fade",
-      directionNav: false,
-  	});
+    // Navbar shadow on scroll
+    $(window).on('scroll', function () {
+        if ($('.custom-navbar').offset().top > 40) {
+            $('.custom-navbar').addClass('navbar-solid');
+        } else {
+            $('.custom-navbar').removeClass('navbar-solid');
+        }
+    });
 
-  	/* isotope
-  	------------------------------*/
-  	if ( $('.iso-box-wrapper').length > 0 ) { 
+    // Smooth scroll for anchors with class .smoothScroll
+    $('a.smoothScroll').on('click', function (event) {
+        var target = this.hash;
+        if (target && $(target).length) {
+            event.preventDefault();
+            $('html, body').animate({
+                scrollTop: $(target).offset().top - 60
+            }, 700);
+        }
+    });
 
-	    var $container 	= $('.iso-box-wrapper'), 
-	    	$imgs 		= $('.iso-box img');
-
-	    $container.imagesLoaded(function () {
-
-	    	$container.isotope({
-				layoutMode: 'fitRows',
-				itemSelector: '.iso-box'
-	    	});
-
-	    	$imgs.load(function(){
-	    		$container.isotope('reLayout');
-	    	})
-
-	    });
-
-	    //filter items on button click
-	    $('.filter-wrapper li a').click(function(){
-
-	        var $this = $(this), filterValue = $this.attr('data-filter');
-
-			$container.isotope({ 
-				filter: filterValue,
-				animationOptions: { 
-				    duration: 750, 
-				    easing: 'linear', 
-				    queue: false, 
-				}              	 
-			});	            
-
-			// don't proceed if already selected 
-			if ( $this.hasClass('selected') ) { 
-				return false; 
-			}
-
-			var filter_wrapper = $this.closest('.filter-wrapper');
-			filter_wrapper.find('.selected').removeClass('selected');
-			$this.addClass('selected');
-
-	      return false;
-	    }); 
-	}
-
-	/* wow
-	-------------------------------*/
-	new WOW().init();
+    // Initialize wow animations
+    if (typeof WOW === 'function') {
+        new WOW().init();
+    }
 });

--- a/views/home.html
+++ b/views/home.html
@@ -1,93 +1,91 @@
 {{ define "content" }}
-	<!-- start home -->
-	<section id="home">
-		<div class="overlay">
-			<div class="flexslider">
-				<ul class="slides">
-					<li>
-						<img src="/static/images/slider/1.jpg" alt="Slide 1">
-						<div class="slider-caption">
-							<div class="templatemo_homewrapper">
-								<h1 style="color: rgb(35,147,224);" class="wow bounceIn">{{ .Home.Home1H1 }}</h3>
-								<h3 class="wow bounce">{{ .Home.Home1H3 }}</h3>
-							</div>
-						</div>
-					</li>
-					<li>
-						<img src="/static/images/slider/2.jpg" alt="Slide 2">
-						<div class="slider-caption">
-							<div class="templatemo_homewrapper">
-								<h1 style="color: black;">{{ .Home.Home2H1 }}</h1>
-								<h3>{{ .Home.Home2H3 }}</h3>
-							</div>
-						</div>
-					</li>
-					<li>
-						<img src="/static/images/slider/3.jpg" alt="Slide 2">
-						<div class="slider-caption">
-							<div class="templatemo_homewrapper">
-								<h1 style="color: orange;">{{ .Home.Home3H1 }}</h1>
-								<h3>{{ .Home.Home3H3 }}</h3>
-							</div>
-						</div>
-					</li>
-				</ul>
-			</div>
-		</div>
-	</section>
-	<!-- end home -->
+{{ $home := .Home }}
+<section id="home" class="hero-section">
+        <div class="container">
+                <div class="row align-middle">
+                        <div class="col-md-6">
+                                <div class="hero-copy">
+                                        <h1 class="hero-title">{{ if $home }}{{ $home.HeroTitle }}{{ else }}LPK Asta Karya{{ end }}</h1>
+                                        <p class="hero-subtitle">{{ if $home }}{{ $home.HeroSubtitle }}{{ else }}Seluruh informasi utama kini tersentralisasi dalam satu dokumen resmi.{{ end }}</p>
+                                        <div class="hero-actions">
+                                                {{ if $home }}
+                                                <a class="btn btn-primary hero-btn" href="{{ $home.DocURL }}" target="_blank" rel="noopener">{{ $home.HeroButtonLabel }}</a>
+                                                <p class="hero-support">{{ $home.HeroSupport }}</p>
+                                                {{ else }}
+                                                <a class="btn btn-primary hero-btn" href="#doc">Lihat Dokumen</a>
+                                                {{ end }}
+                                        </div>
+                                </div>
+                        </div>
+                        <div class="col-md-6">
+                                <div class="hero-illustration">
+                                        <div class="hero-blob"></div>
+                                        <div class="hero-card">
+                                                <span class="hero-card-label"><i class="fa fa-file-text-o"></i> Google Docs</span>
+                                                <h2 class="hero-card-title">{{ if $home }}{{ $home.HeroButtonLabel }}{{ else }}Dokumen Resmi{{ end }}</h2>
+                                                <p class="hero-card-text">{{ if $home }}{{ $home.HeroSupport }}{{ else }}Buka dokumen untuk membaca seluruh konten terbaru.{{ end }}</p>
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+        </div>
+</section>
 
-	<!-- start map -->
-	<div class="divider_map">
-		<div class="overlay_map">
-			<div class="container">
-				<div class="row">
-					<div class="divider_map-des">
-						<h3 class="text-uppercase">{{ .Home.MapHeader }} : {{ .Home.MapContent }} </h3>
-						<div id="map"></div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-	<!-- end map -->
+<section id="highlights" class="highlights-section">
+        <div class="container">
+                <div class="section-heading text-center">
+                        <h2 class="section-title">{{ if $home }}{{ $home.HeroTitle }}{{ else }}Sorotan Utama{{ end }}</h2>
+                        <p class="section-subtitle">{{ if $home }}{{ $home.HeroSubtitle }}{{ else }}Pelajari informasi terkurasi langsung dari dokumen utama.{{ end }}</p>
+                </div>
+                <div class="row">
+                        {{ if and $home (gt (len $home.Highlights) 0) }}
+                        {{ range $home.Highlights }}
+                        <div class="col-md-4 col-sm-6">
+                                <div class="highlight-card wow fadeInUp" data-wow-delay="0.2s">
+                                        <div class="highlight-icon"><i class="fa {{ .Icon }}" aria-hidden="true"></i></div>
+                                        <h3 class="highlight-title">{{ .Title }}</h3>
+                                        <p class="highlight-description">{{ .Description }}</p>
+                                </div>
+                        </div>
+                        {{ end }}
+                        {{ else }}
+                        <div class="col-md-12">
+                                <div class="highlight-card">
+                                        <h3 class="highlight-title">Konten disiapkan</h3>
+                                        <p class="highlight-description">Tambahkan poin-poin utama melalui berkas konfigurasi bahasa.</p>
+                                </div>
+                        </div>
+                        {{ end }}
+                </div>
+        </div>
+</section>
 
-	{{ template "about" . }}
-
-	{{ template "program" . }}
-
-	<!-- start divider -->
-	<div class="divider">
-		<div class="overlay">
-			<div class="container">
-				<div class="row">
-					<div class="divider-des">
-						<h3 class="text-uppercase">LPK ASTA KARYA</h3>
-						<p>Lembaga Penyalur Kerja Asta Karya Indonesi</p>
-						<!-- <button class="btn btn-default text-uppercase">Download</button> -->
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-	<!-- end divider -->
-	{{ template "training" . }}
-
-	<!-- start divider -->
-	<div style="margin-top: 50px; margin-bottom: 50px;" class="divider">
-		<div class="overlay">
-			<div class="container">
-				<div class="row">
-					<div class="divider-des">
-						<h3 class="text-uppercase">LPK ASTA KARYA</h3>
-						<p>Lembaga Penyalur Kerja Asta Karya Indonesi</p>
-						<!-- <button class="btn btn-default text-uppercase">Download</button> -->
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-	<!-- end divider -->
-	
-	{{ template "media" . }}
+<section id="doc" class="document-preview">
+        <div class="container">
+                <div class="preview-card wow fadeInUp" data-wow-delay="0.1s">
+                        <div class="preview-header">
+                                <div class="preview-title">
+                                        <span class="preview-label"><i class="fa fa-google"></i> Google Docs</span>
+                                        <h2>{{ if $home }}{{ $home.HeroTitle }}{{ else }}Dokumen Resmi LPK Asta Karya{{ end }}</h2>
+                                </div>
+                                {{ if $home }}
+                                <a class="btn btn-outline" href="{{ $home.DocURL }}" target="_blank" rel="noopener">
+                                        <i class="fa fa-external-link"></i>
+                                        {{ $home.HeroButtonLabel }}
+                                </a>
+                                {{ end }}
+                        </div>
+                        {{ if $home }}
+                        <div class="preview-frame">
+                                <iframe src="{{ $home.DocEmbedURL }}" title="LPK Asta Karya Google Docs" loading="lazy" allowfullscreen></iframe>
+                        </div>
+                        <p class="preview-note">{{ $home.DocNote }}</p>
+                        {{ else }}
+                        <div class="preview-empty">
+                                <p>Konten dokumen belum tersedia. Perbarui berkas konfigurasi untuk menautkan dokumen resmi.</p>
+                        </div>
+                        {{ end }}
+                </div>
+        </div>
+</section>
 {{ end }}

--- a/views/layout.html
+++ b/views/layout.html
@@ -1,84 +1,79 @@
 <!DOCTYPE html>
 <html lang="{{ .Lang }}">
 <head>
-	<meta charset="utf-8">
-	<title>{{ .Header.Title }}</title>
-    <link rel="icon" type="image/x-icon" href="/static/images/favicon.ico">
-	<meta http-equiv="X-UA-Compatible" content="IE=Edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<meta name="keywords" content="">
-	<meta name="description" content="">
-    <!-- 
-	Workforce CSS Template
-	https://templatemo.com/tm-461-workforce
-    -->
-	<link href='http://fonts.googleapis.com/css?family=Montserrat:400,700' rel='stylesheet' type='text/css'>
-	<link rel="stylesheet" href="/static/css/animate.min.css">
-	<link rel="stylesheet" href="/static/css/bootstrap.min.css">
-	<link rel="stylesheet" href="/static/css/font-awesome.min.css">		
-	<link rel="stylesheet" href="/static/css/templatemo-style.css">
+        <meta charset="utf-8">
+        <title>{{ .Header.Title }}</title>
+        <link rel="icon" type="image/x-icon" href="/static/images/favicon.ico">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="description" content="LPK Asta Karya official documentation portal">
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="/static/css/animate.min.css">
+        <link rel="stylesheet" href="/static/css/bootstrap.min.css">
+        <link rel="stylesheet" href="/static/css/font-awesome.min.css">
+        <link rel="stylesheet" href="/static/css/custom.css">
 </head>
-<body data-spy="scroll" data-offset="50" data-target=".navbar-collapse">
-	<div class="preloader">
-		<div class="sk-spinner sk-spinner-rotating-plane"></div>
-	</div>
-	<nav class="navbar navbar-fixed-top custom-navbar">
-		<div class="container">
-			<div class="navbar-header">
-				<a href="/" class="navbar-brand">
-                    <img src="/static/images/asta-karya.png" alt="Logo" style="max-height: 76px; margin-top: -30px;">
-                </a>
-			</div>
-			<div class="collapse navbar-collapse">
-				<ul class="nav navbar-nav navbar-right">
-					<li><a href="#home" class="smoothScroll">{{ .Header.Home }}</a></li>
-					<li><a href="#about" class="smoothScroll">{{ .Header.About }}</a></li>
-					<li><a href="#program" class="smoothScroll">{{ .Header.Program }}</a></li>
-					<li><a href="#training" class="smoothScroll">{{ .Header.Training }}</a></li>
-					<li><a href="#media" class="smoothScroll">{{ .Header.Media }}</a></li>
-					<li><a href="galery" class="smoothScroll">{{ .Header.Galery }}</a></li>
-					<li class="nav-item dropdown">
-						<a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown">🌐 Language</a>
-						<div class="dropdown-menu">
-							<a href="/?lang=id" class="dropdown-item">🇮🇩 Indonesia</a>
-							<a href="/?lang=jp" class="dropdown-item">🇯🇵 日本語</a>
-						</div>
-					</li>
-					
-				</ul>
-			</div>
-		</div>
-	</nav>
+<body class="site" data-spy="scroll" data-offset="70" data-target="#main-nav">
+        <div class="preloader">
+                <div class="sk-spinner sk-spinner-rotating-plane"></div>
+        </div>
+        <header class="site-header">
+                <nav class="navbar navbar-fixed-top custom-navbar">
+                        <div class="container">
+                                <div class="navbar-header">
+                                        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#main-nav" aria-expanded="false" aria-controls="main-nav">
+                                                <span class="sr-only">Toggle navigation</span>
+                                                <span class="icon-bar"></span>
+                                                <span class="icon-bar"></span>
+                                                <span class="icon-bar"></span>
+                                        </button>
+                                        <a href="/" class="navbar-brand logo-wrapper">
+                                                <img src="/static/images/asta-karya.png" alt="LPK Asta Karya" class="navbar-brand-logo">
+                                                <span class="navbar-brand-text">LPK Asta Karya</span>
+                                        </a>
+                                </div>
+                                <div class="collapse navbar-collapse" id="main-nav">
+                                        <ul class="nav navbar-nav navbar-right">
+                                                <li><a href="#home" class="smoothScroll">{{ .Header.Home }}</a></li>
+                                                <li><a href="#highlights" class="smoothScroll">{{ .Header.Highlights }}</a></li>
+                                                <li><a href="#doc" class="smoothScroll">{{ .Header.Document }}</a></li>
+                                                <li><a href="/galery">{{ .Header.Galery }}</a></li>
+                                                <li class="dropdown nav-language">
+                                                        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">🌐</a>
+                                                        <ul class="dropdown-menu">
+                                                                <li><a href="/?lang=id">🇮🇩 Indonesia</a></li>
+                                                                <li><a href="/?lang=jp">🇯🇵 日本語</a></li>
+                                                        </ul>
+                                                </li>
+                                        </ul>
+                                </div>
+                        </div>
+                </nav>
+        </header>
 
-	<section id="content">
-        {{ template "content" . }}
-    </section>
-	
-	<!-- end contact -->
-	<footer>
-		<div class="container">
-			<div class="row">
-				<div class="col-md-12">
-					<ul class="social-icon wow fadeIn" data-wow-delay="0.3s">
-						<li><a href="#" class="fa fa-facebook"></a></li>
-						<li><a href="#" class="fa fa-twitter"></a></li>
-						<li><a href="#" class="fa fa-instagram"></a></li>
-					</ul>
-					<!-- <p class="wow bounceIn">Copyright &copy; 2018 <span>Workforce</span> Studio  -->
-                    <!-- . Design: <a rel="nofollow noopener" href="https://templatemo.com"><span>templatemo</span></a></p> -->
-				</div>
-			</div>
-		</div>
-	</footer>
-	<script src="/static/js/jquery.js"></script>
-	<script src="/static/js/bootstrap.min.js"></script>
-	<script src="/static/js/jquery.flexslider.js"></script>
-	<script src="/static/js/isotope.js"></script>
-	<script src="/static/js/imagesloaded.min.js"></script>
-	<script src="/static/js/smoothscroll.js"></script>
-	<script src="/static/js/wow.min.js"></script>
-	<script src="/static/js/custom.js"></script>
-	<script src="/static/js/mapdata.js"></script>
-    <script src="/static/js/countrymap.js"></script>
+        <main id="content" class="site-content">
+                {{ template "content" . }}
+        </main>
+
+        <footer class="site-footer">
+                <div class="container">
+                        <div class="row">
+                                <div class="col-md-12">
+                                        <p class="footer-text">© 2024 LPK Asta Karya. All rights reserved.</p>
+                                        <div class="footer-links">
+                                                <a href="{{ if .Home }}{{ .Home.DocURL }}{{ else }}#{{ end }}" target="_blank" rel="noopener" class="footer-link">{{ .Header.Document }}</a>
+                                                <a href="/galery" class="footer-link">{{ .Header.Galery }}</a>
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+        </footer>
+
+        <script src="/static/js/jquery.js"></script>
+        <script src="/static/js/bootstrap.min.js"></script>
+        <script src="/static/js/wow.min.js"></script>
+        <script src="/static/js/custom.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redesign the landing layout with a simplified navigation and footer geared toward the documentation portal
- embed the shared Google Docs link in the homepage and update locale content/models to drive the new hero and highlight sections
- add a dedicated stylesheet and streamlined JavaScript for the refreshed experience

## Testing
- GOPROXY=off go build ./...


------
https://chatgpt.com/codex/tasks/task_e_68da2854c1d88330a2c7e5b7a21d3e19