### PR TITLE
Revamp home page with full Asta Karya profile content

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -85,7 +85,23 @@ a:focus {
 .hero-section {
     position: relative;
     padding: 160px 0 120px;
-    background: linear-gradient(135deg, rgba(27, 110, 243, 0.08), rgba(255, 255, 255, 0));
+    background-image: linear-gradient(135deg, rgba(245, 247, 251, 0.88), rgba(245, 247, 251, 0.45)), url('/static/images/slider/1.jpg');
+    background-size: cover;
+    background-position: center;
+    overflow: hidden;
+}
+
+.hero-section::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(255, 255, 255, 0.94), rgba(255, 255, 255, 0.72));
+    z-index: 0;
+}
+
+.hero-section > .container {
+    position: relative;
+    z-index: 1;
 }
 
 .hero-section .row {
@@ -198,139 +214,313 @@ a:focus {
     font-size: 0.95rem;
 }
 
+.hero-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 14px;
+    border-radius: 999px;
+    background: rgba(27, 110, 243, 0.12);
+    color: var(--primary-dark);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    font-size: 0.8rem;
+    margin-bottom: 18px;
+}
+
+.hero-stats {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 18px;
+    margin-top: 28px;
+}
+
+.hero-stat {
+    background: rgba(27, 110, 243, 0.08);
+    border-radius: 16px;
+    padding: 16px 18px;
+    text-align: center;
+}
+
+.hero-stat-number {
+    display: block;
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: var(--primary-dark);
+}
+
+.hero-stat-label {
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.section {
+    padding: 120px 0;
+}
+
+.section-muted {
+    background: #ffffff;
+}
+
 .section-heading {
-    margin-bottom: 48px;
+    margin-bottom: 56px;
+}
+
+.section-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 14px;
+    border-radius: 999px;
+    background: rgba(27, 110, 243, 0.1);
+    color: var(--primary-dark);
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 0.78rem;
+    letter-spacing: 0.06em;
+    margin-bottom: 16px;
 }
 
 .section-title {
-    font-size: 2rem;
+    font-size: 2.3rem;
     font-weight: 600;
-    margin-bottom: 12px;
+    margin-bottom: 18px;
+    color: var(--text-color);
 }
 
 .section-subtitle {
     color: var(--muted);
-    max-width: 640px;
+    max-width: 720px;
     margin: 0 auto;
+    font-size: 1.05rem;
 }
 
-.highlights-section {
-    padding: 120px 0;
+.content-grid {
+    display: grid;
+    gap: 30px;
 }
 
-.highlight-card {
+.content-grid.grid-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.content-grid.grid-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.content-card,
+.info-card,
+.story-card,
+.vision-card,
+.detail-card,
+.module-card,
+.resource-card {
     background: #ffffff;
-    border-radius: 20px;
+    border-radius: 22px;
     padding: 32px;
-    margin-bottom: 30px;
     box-shadow: var(--card-shadow);
     height: 100%;
-    transition: transform 0.25s ease, box-shadow 0.25s ease;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
-.highlight-card:hover {
-    transform: translateY(-6px);
-    box-shadow: 0 26px 50px rgba(27, 110, 243, 0.18);
+.content-card:hover,
+.info-card:hover,
+.story-card:hover,
+.vision-card:hover,
+.detail-card:hover,
+.module-card:hover,
+.resource-card:hover {
+    transform: translateY(-8px);
+    box-shadow: 0 28px 58px rgba(15, 34, 58, 0.16);
 }
 
-.highlight-icon {
-    width: 48px;
-    height: 48px;
-    border-radius: 14px;
-    background: rgba(27, 110, 243, 0.12);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--primary);
+.content-card-title,
+.info-card-title,
+.story-card-title,
+.vision-card-title,
+.module-card-title,
+.resource-card-title,
+.detail-card-title {
     font-size: 1.25rem;
-    margin-bottom: 18px;
-}
-
-.highlight-title {
-    font-size: 1.2rem;
     font-weight: 600;
-    margin-bottom: 12px;
+    margin-bottom: 16px;
 }
 
-.highlight-description {
-    color: var(--muted);
+.content-card-subtitle,
+.module-card h4,
+.vision-card h4 {
+    font-size: 1.05rem;
+    font-weight: 600;
+    margin: 24px 0 12px;
+}
+
+.info-list {
     margin: 0;
 }
 
-.document-preview {
-    padding: 80px 0 120px;
+.info-list div {
+    margin-bottom: 18px;
 }
 
-.preview-card {
-    background: #ffffff;
-    border-radius: 28px;
-    box-shadow: var(--card-shadow);
-    padding: 40px;
+.info-list dt {
+    font-weight: 600;
+    color: var(--muted);
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    margin-bottom: 6px;
 }
 
-.preview-header {
+.info-list dd {
+    margin: 0;
+}
+
+.info-list.compact div {
+    margin-bottom: 14px;
+}
+
+.story-card p,
+.content-card p,
+.vision-card p,
+.detail-card p,
+.resource-card p {
+    color: var(--muted);
+    font-size: 0.98rem;
+}
+
+.vision-card ul,
+.module-card ul,
+.detail-card ul {
+    padding-left: 18px;
+    margin: 12px 0 0;
+    color: var(--muted);
+}
+
+.vision-card li,
+.module-card li,
+.detail-card li {
+    margin-bottom: 10px;
+    line-height: 1.6;
+}
+
+.tag-list {
     display: flex;
     flex-wrap: wrap;
-    align-items: center;
-    justify-content: space-between;
-    gap: 20px;
-    margin-bottom: 30px;
+    gap: 10px;
+    margin: 18px 0 0;
+    padding: 0;
+    list-style: none;
 }
 
-.preview-label {
-    display: inline-flex;
-    align-items: center;
-    gap: 10px;
-    padding: 6px 14px;
+.tag-list li {
+    padding: 8px 14px;
     border-radius: 999px;
-    background: rgba(255, 183, 77, 0.18);
-    color: #e57b00;
-    font-weight: 600;
+    background: rgba(27, 110, 243, 0.12);
+    color: var(--primary-dark);
+    font-weight: 500;
+    font-size: 0.9rem;
 }
 
-.btn.btn-outline {
-    border: 1px solid var(--primary);
-    color: var(--primary);
-    border-radius: 14px;
-    padding: 12px 24px;
-    font-weight: 600;
-    background: transparent;
-    display: inline-flex;
-    align-items: center;
-    gap: 10px;
+.organization-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+    gap: 40px;
+    align-items: start;
 }
 
-.btn.btn-outline:hover,
-.btn.btn-outline:focus {
-    background: var(--primary);
-    color: #ffffff;
-}
-
-.preview-frame {
-    border-radius: 20px;
-    overflow: hidden;
-    box-shadow: inset 0 0 0 1px rgba(27, 110, 243, 0.08);
-}
-
-.preview-frame iframe {
-    width: 100%;
-    min-height: 640px;
-    border: none;
+.organization-visual {
     background: #ffffff;
+    border-radius: 26px;
+    box-shadow: var(--card-shadow);
+    padding: 28px;
 }
 
-.preview-note {
-    margin-top: 20px;
-    color: var(--muted);
-    font-size: 0.95rem;
-}
-
-.preview-empty {
-    padding: 40px;
+.organization-image {
+    width: 100%;
     border-radius: 18px;
-    background: rgba(27, 110, 243, 0.08);
+    box-shadow: 0 16px 40px rgba(15, 34, 58, 0.14);
+}
+
+.organization-caption {
+    margin-top: 14px;
     text-align: center;
     color: var(--muted);
+    font-size: 0.92rem;
+}
+
+.organization-details {
+    display: grid;
+    gap: 20px;
+}
+
+.detail-list {
+    margin: 14px 0 0;
+    padding-left: 18px;
+    color: var(--muted);
+}
+
+.timeline {
+    display: grid;
+    gap: 26px;
+    margin-bottom: 50px;
+}
+
+.timeline-item {
+    display: grid;
+    grid-template-columns: 80px minmax(0, 1fr);
+    gap: 24px;
+    align-items: center;
+}
+
+.timeline-step {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 68px;
+    height: 68px;
+    border-radius: 22px;
+    background: linear-gradient(135deg, rgba(27, 110, 243, 0.14), rgba(27, 110, 243, 0.28));
+    font-weight: 700;
+    font-size: 1.25rem;
+    color: var(--primary-dark);
+}
+
+.timeline-content {
+    background: #ffffff;
+    border-radius: 22px;
+    padding: 24px 28px;
+    box-shadow: var(--card-shadow);
+}
+
+.timeline-content h3 {
+    margin-top: 0;
+    margin-bottom: 12px;
+    font-size: 1.2rem;
+}
+
+.timeline-content p {
+    margin: 0;
+    color: var(--muted);
+}
+
+.recruitment-note {
+    max-width: 760px;
+    margin: 0 auto;
+}
+
+.resource-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--primary);
+    font-weight: 600;
+    margin-top: 18px;
+}
+
+.resource-link:hover,
+.resource-link:focus {
+    color: var(--primary-dark);
 }
 
 .site-footer {
@@ -361,6 +551,12 @@ a:focus {
     color: #ffffff;
 }
 
+@media (max-width: 1199px) {
+    .content-grid.grid-3 {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
 @media (max-width: 991px) {
     .hero-section {
         padding-top: 140px;
@@ -377,6 +573,10 @@ a:focus {
     .hero-illustration {
         margin-top: 40px;
     }
+
+    .organization-layout {
+        grid-template-columns: 1fr;
+    }
 }
 
 @media (max-width: 767px) {
@@ -384,21 +584,36 @@ a:focus {
         padding: 12px 16px;
     }
 
-    .preview-frame iframe {
-        min-height: 520px;
+    .content-grid.grid-2,
+    .content-grid.grid-3 {
+        grid-template-columns: 1fr;
+    }
+
+    .timeline-item {
+        grid-template-columns: 1fr;
+        gap: 16px;
+    }
+
+    .timeline-step {
+        width: 60px;
+        height: 60px;
+    }
+
+    .hero-stats {
+        grid-template-columns: 1fr 1fr;
     }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 575px) {
     .hero-card {
-        padding: 24px;
+        padding: 26px;
     }
 
-    .highlight-card {
-        padding: 24px;
+    .hero-stats {
+        grid-template-columns: 1fr;
     }
 
-    .preview-card {
-        padding: 28px 20px;
+    .section {
+        padding: 90px 0;
     }
 }

--- a/views/home.html
+++ b/views/home.html
@@ -1,29 +1,38 @@
 {{ define "content" }}
-{{ $home := .Home }}
 <section id="home" class="hero-section">
         <div class="container">
                 <div class="row align-middle">
-                        <div class="col-md-6">
+                        <div class="col-lg-6">
                                 <div class="hero-copy">
-                                        <h1 class="hero-title">{{ if $home }}{{ $home.HeroTitle }}{{ else }}LPK Asta Karya{{ end }}</h1>
-                                        <p class="hero-subtitle">{{ if $home }}{{ $home.HeroSubtitle }}{{ else }}Seluruh informasi utama kini tersentralisasi dalam satu dokumen resmi.{{ end }}</p>
+                                        <span class="hero-eyebrow">LPK Asta Karya</span>
+                                        <h1 class="hero-title">Membuka Gerbang Karier Global bagi Talenta Indonesia</h1>
+                                        <p class="hero-subtitle">Program terintegrasi yang memadukan pelatihan teknis, pembinaan karakter, dan pemahaman budaya Jepang untuk mencetak generasi profesional yang siap bersaing di dunia kerja internasional.</p>
                                         <div class="hero-actions">
-                                                {{ if $home }}
-                                                <a class="btn btn-primary hero-btn" href="{{ $home.DocURL }}" target="_blank" rel="noopener">{{ $home.HeroButtonLabel }}</a>
-                                                <p class="hero-support">{{ $home.HeroSupport }}</p>
-                                                {{ else }}
-                                                <a class="btn btn-primary hero-btn" href="#doc">Lihat Dokumen</a>
-                                                {{ end }}
+                                                <a class="btn btn-primary hero-btn smoothScroll" href="#foreword">
+                                                        <span>Jelajahi Profil</span>
+                                                        <i class="fa fa-arrow-down"></i>
+                                                </a>
+                                                <p class="hero-support">Mulai dari pengenalan lembaga hingga proses rekrutmen — semua tersaji dalam satu halaman komprehensif.</p>
                                         </div>
                                 </div>
                         </div>
-                        <div class="col-md-6">
+                        <div class="col-lg-6">
                                 <div class="hero-illustration">
                                         <div class="hero-blob"></div>
                                         <div class="hero-card">
-                                                <span class="hero-card-label"><i class="fa fa-file-text-o"></i> Google Docs</span>
-                                                <h2 class="hero-card-title">{{ if $home }}{{ $home.HeroButtonLabel }}{{ else }}Dokumen Resmi{{ end }}</h2>
-                                                <p class="hero-card-text">{{ if $home }}{{ $home.HeroSupport }}{{ else }}Buka dokumen untuk membaca seluruh konten terbaru.{{ end }}</p>
+                                                <span class="hero-card-label"><i class="fa fa-graduation-cap"></i> Program Pemagangan Jepang</span>
+                                                <h2 class="hero-card-title">Sejak 2016</h2>
+                                                <p class="hero-card-text">Menghubungkan pemuda Indonesia dengan peluang belajar dan bekerja di Jepang melalui kurikulum modern dan tim pelatih berpengalaman.</p>
+                                                <div class="hero-stats">
+                                                        <div class="hero-stat">
+                                                                <span class="hero-stat-number">100+</span>
+                                                                <span class="hero-stat-label">Kapasitas peserta</span>
+                                                        </div>
+                                                        <div class="hero-stat">
+                                                                <span class="hero-stat-number">3</span>
+                                                                <span class="hero-stat-label">Bahasa resmi konten</span>
+                                                        </div>
+                                                </div>
                                         </div>
                                 </div>
                         </div>
@@ -31,60 +40,405 @@
         </div>
 </section>
 
-<section id="highlights" class="highlights-section">
+<section id="foreword" class="section">
         <div class="container">
                 <div class="section-heading text-center">
-                        <h2 class="section-title">{{ if $home }}{{ $home.HeroTitle }}{{ else }}Sorotan Utama{{ end }}</h2>
-                        <p class="section-subtitle">{{ if $home }}{{ $home.HeroSubtitle }}{{ else }}Pelajari informasi terkurasi langsung dari dokumen utama.{{ end }}</p>
+                        <span class="section-eyebrow">Kata Pengantar</span>
+                        <h2 class="section-title">Dedikasi LPK Asta Karya untuk Masa Depan Global</h2>
+                        <p class="section-subtitle">Sambutan resmi dalam tiga bahasa sebagai wujud komitmen internasional lembaga.</p>
                 </div>
-                <div class="row">
-                        {{ if and $home (gt (len $home.Highlights) 0) }}
-                        {{ range $home.Highlights }}
-                        <div class="col-md-4 col-sm-6">
-                                <div class="highlight-card wow fadeInUp" data-wow-delay="0.2s">
-                                        <div class="highlight-icon"><i class="fa {{ .Icon }}" aria-hidden="true"></i></div>
-                                        <h3 class="highlight-title">{{ .Title }}</h3>
-                                        <p class="highlight-description">{{ .Description }}</p>
-                                </div>
-                        </div>
-                        {{ end }}
-                        {{ else }}
-                        <div class="col-md-12">
-                                <div class="highlight-card">
-                                        <h3 class="highlight-title">Konten disiapkan</h3>
-                                        <p class="highlight-description">Tambahkan poin-poin utama melalui berkas konfigurasi bahasa.</p>
-                                </div>
-                        </div>
-                        {{ end }}
+                <div class="content-grid grid-3">
+                        <article class="content-card">
+                                <h3 class="content-card-title">Bahasa Indonesia</h3>
+                                <p>Puji dan syukur kami panjatkan ke hadirat Tuhan Yang Maha Esa, karena atas rahmat dan karunia-Nya, kami dapat menyusun dan menghadirkan company profile Lembaga Pelatihan Kerja (LPK) Asta Karya ke Jepang ini. Lembaga kami berkomitmen untuk memberikan program pelatihan yang berkualitas dan sesuai dengan standar kebutuhan pasar kerja di Jepang, sehingga para peserta pelatihan dapat memiliki keterampilan dan kompetensi yang memadai untuk bersaing secara global.</p>
+                                <p>Program pelatihan ini dirancang dengan tujuan memberikan bekal keahlian praktis dan wawasan budaya yang mendalam tentang Jepang, sehingga para peserta tidak hanya siap dari segi teknis, tetapi juga mampu menyesuaikan diri dengan lingkungan kerja dan sosial di sana. Kami percaya, melalui pelatihan ini, kesempatan untuk bekerja dan berkarir di Jepang dapat diwujudkan secara optimal.</p>
+                                <p>Kami mengucapkan terima kasih kepada semua pihak yang telah mendukung terlaksananya program ini, dan berharap para peserta dapat memanfaatkan kesempatan ini dengan sebaik-baiknya untuk masa depan yang lebih cerah.</p>
+                                <p>Semoga program pelatihan ini membawa manfaat besar dan menjadi langkah awal yang baik dalam meraih kesuksesan di dunia kerja internasional.</p>
+                        </article>
+                        <article class="content-card">
+                                <h3 class="content-card-title">日本語</h3>
+                                <p>ごあいさつ<br>まず初めに、LPK ASTA KARYA職業訓練機関（以下「アスタ・カルヤ」）の企業紹介資料を皆様にお届けできることを、心より光栄に存じます。これはひとえに神のご加護と関係者の皆様のご支援の賜物であると、深く感謝申し上げます。</p>
+                                <p>ASTA KARYA は、日本の労働市場のニーズに応じた質の高い訓練を提供することを使命とし、参加者が国際社会でも通用するスキルと能力を身につけられるよう努めております。</p>
+                                <p>訓練プログラムは、実践的な技能の習得だけでなく、日本の文化や社会に対する深い理解も重視して設計されています。これにより、参加者は技術面のみならず、日本での職場環境や生活環境にも柔軟に適応できる人材として成長することが可能となります。</p>
+                                <p>訓練生の皆様には、この貴重な機会を最大限に活かし、より明るい未来への一歩を踏み出していただきたいと期待おります。または、この職業訓練プログラムが、皆様にとって大きな価値をもたらし、国際的なキャリア成功への第一歩となることを、心から願っております。</p>
+                        </article>
+                        <article class="content-card">
+                                <h3 class="content-card-title">English</h3>
+                                <p>We are pleased to present the company profile of Lembaga Pelatihan Kerja (LPK) Asta Karya, made possible through the grace and blessings of Almighty God. This profile reflects our dedication to providing high-quality training programs that are aligned with the standards and demands of the Japanese labor market. Our mission is to equip participants with the skills, knowledge, and competencies required to excel and remain competitive in the global workforce.</p>
+                                <p>The training programs we offer are designed not only to develop practical expertise but also to instill a deep understanding of Japanese culture. This holistic approach ensures that participants are well-prepared to adapt effectively to both professional and social environments in Japan. Through this program, we aim to maximize opportunities for employment and long-term career development in Japan.</p>
+                                <p>We extend our sincere gratitude to all stakeholders who have contributed to the realization of this program. We are confident that the participants will take full advantage of this opportunity as a strategic investment in their future success.</p>
+                                <p>We firmly believe that this initiative will generate significant value and serve as a solid foundation for building sustainable careers in the international labor market.</p>
+                        </article>
                 </div>
         </div>
 </section>
 
-<section id="doc" class="document-preview">
+<section id="profile" class="section section-muted">
         <div class="container">
-                <div class="preview-card wow fadeInUp" data-wow-delay="0.1s">
-                        <div class="preview-header">
-                                <div class="preview-title">
-                                        <span class="preview-label"><i class="fa fa-google"></i> Google Docs</span>
-                                        <h2>{{ if $home }}{{ $home.HeroTitle }}{{ else }}Dokumen Resmi LPK Asta Karya{{ end }}</h2>
+                <div class="section-heading text-center">
+                        <span class="section-eyebrow">Profil Lembaga</span>
+                        <h2 class="section-title">Informasi Utama LPK Asta Karya</h2>
+                        <p class="section-subtitle">Identitas dan kontak resmi lembaga dalam tiga bahasa untuk kemudahan kolaborasi internasional.</p>
+                </div>
+                <div class="content-grid grid-3">
+                        <article class="info-card">
+                                <h3 class="info-card-title">Bahasa Indonesia</h3>
+                                <dl class="info-list">
+                                        <div><dt>Nama Lembaga</dt><dd>Lembaga Pelatihan Kerja (LPK) Asta Karya</dd></div>
+                                        <div><dt>Nama Pimpinan</dt><dd>Muhammad Arif Ramadhan</dd></div>
+                                        <div><dt>Kantor Pusat</dt><dd>Ruko No.3B, Jl. Pasar Minggu Raya KM.19 No.3B, RT.003 RW.05, Kelurahan Pejaten Barat, Kecamatan Pasar Minggu, Kota Jakarta Selatan, DKI Jakarta, Indonesia 12510</dd></div>
+                                        <div><dt>Telepon</dt><dd><a href="tel:+6282210020247">+62 822-1002-0247</a> (WA &amp; LINE)</dd></div>
+                                        <div><dt>Training Center</dt><dd>Jl. H. Ibrahim Adjie No.99, RT.03 RW.02, Kelurahan Cijawura, Kecamatan Buah Batu, Kota Bandung, Indonesia 40287</dd></div>
+                                        <div><dt>Telepon Training Center</dt><dd><a href="tel:+6282210020246">+62 822-1002-0246</a> (WA &amp; LINE)</dd></div>
+                                        <div><dt>Email</dt><dd><a href="mailto:astakarya.adm@gmail.com">astakarya.adm@gmail.com</a></dd></div>
+                                        <div><dt>Kontak Person</dt><dd><a href="tel:+6282299338862">+62 822-9933-8862</a></dd></div>
+                                        <div><dt>Nomor Izin SO</dt><dd>2/4473/HK.03.01/XI/2023</dd></div>
+                                </dl>
+                        </article>
+                        <article class="info-card">
+                                <h3 class="info-card-title">日本語</h3>
+                                <dl class="info-list">
+                                        <div><dt>訓練機関名</dt><dd>LPK Asta Karya（アスタ・カルヤ職業訓練機関）</dd></div>
+                                        <div><dt>代表者名</dt><dd>ムハンマド・アリフ・ラマダン</dd></div>
+                                        <div><dt>本社所在地</dt><dd>Ruko No.3B, Jl. Pasar Minggu Raya KM.19 No.3B, RT.003 / RW.05, Kelurahan Pejaten Barat, Kecamatan Pasar Minggu, Jakarta Selatan, DKI Jakarta, Indonesia 12510</dd></div>
+                                        <div><dt>電話番号</dt><dd><a href="tel:+6282210020247">+62 822-1002-0247</a>（インドネシア語対応 / Whatsapp &amp; LINE）<br><a href="tel:+6282299338862">+62 822-9933-8862</a>（日本語対応）</dd></div>
+                                        <div><dt>トレーニングセンター所在地</dt><dd>Jl. H. Ibrahim Adjie No.99, RT.03 / RW.02, Cijawura, Buah Batu, Kota Bandung, Indonesia 40287</dd></div>
+                                        <div><dt>電話番号</dt><dd><a href="tel:+6282210020246">+62 822-1002-0246</a>（インドネシア語対応 / Whatsapp &amp; LINE）<br><a href="tel:+6282299338862">+62 822-9933-8862</a>（日本語対応）</dd></div>
+                                        <div><dt>Eメール</dt><dd><a href="mailto:astakarya.adm@gmail.com">astakarya.adm@gmail.com</a></dd></div>
+                                        <div><dt>送出機関許可番号</dt><dd>2/4473/HK.03.01/XI/2023</dd></div>
+                                </dl>
+                        </article>
+                        <article class="info-card">
+                                <h3 class="info-card-title">English</h3>
+                                <dl class="info-list">
+                                        <div><dt>Company Name</dt><dd>Lembaga Pelatihan Kerja (LPK) Asta Karya</dd></div>
+                                        <div><dt>Director</dt><dd>Muhammad Arif Ramadhan</dd></div>
+                                        <div><dt>Head Office</dt><dd>Ruko No.3B, Jl. Pasar Minggu Raya KM.19 No.3B, RT.003 RW.05, Kelurahan Pejaten Barat, Kecamatan Pasar Minggu, South Jakarta, DKI Jakarta, Indonesia 12510</dd></div>
+                                        <div><dt>Phone</dt><dd><a href="tel:+6282210020247">+62 822-1002-0247</a> (WA &amp; LINE)<br><a href="tel:+6282299338862">+62 822-9933-8862</a></dd></div>
+                                        <div><dt>Training Center</dt><dd>Jl. H. Ibrahim Adjie No.99, RT.03 / RW.02, Cijawura, Buah Batu District, Bandung City, Indonesia 40287</dd></div>
+                                        <div><dt>Training Center Phone</dt><dd><a href="tel:+6282210020246">+62 822-1002-0246</a> (WA &amp; LINE)<br><a href="tel:+6282299338862">+62 822-9933-8862</a></dd></div>
+                                        <div><dt>Email</dt><dd><a href="mailto:astakarya.adm@gmail.com">astakarya.adm@gmail.com</a></dd></div>
+                                        <div><dt>Sending Organization Register Number</dt><dd>2/4473/HK.03.01/XI/2023</dd></div>
+                                </dl>
+                        </article>
+                </div>
+        </div>
+</section>
+
+<section id="background" class="section">
+        <div class="container">
+                <div class="section-heading text-center">
+                        <span class="section-eyebrow">Latar Belakang</span>
+                        <h2 class="section-title">Perjalanan Asta Karya Mewujudkan Mimpi ke Jepang</h2>
+                        <p class="section-subtitle">Cerita pendirian dan nilai yang dipegang teguh dalam membina generasi muda.</p>
+                </div>
+                <div class="content-grid grid-3">
+                        <article class="story-card">
+                                <h3 class="story-card-title">Bahasa Indonesia</h3>
+                                <p>Lembaga Pelatihan Kerja (LPK) Asta Karya merupakan Sending Organization (SO) resmi yang didirikan pada bulan Desember 2016 dan berlokasi di Tebet, Jakarta Selatan. Lembaga ini berada di bawah naungan PT. Ladang Berdikari Indonesia. Pendirinya merupakan seorang alumni dari salah satu universitas di Indonesia dengan latar belakang pendidikan di bidang Bahasa Jepang, serta lulusan dari Sekolah Bahasa Jepang (Nihongo Gakkou) di Prefektur Shizuoka, Jepang.</p>
+                                <p>LPK Asta Karya didirikan dengan tujuan mulia, yaitu memberikan kesempatan bagi generasi muda Indonesia untuk merasakan secara langsung atmosfer belajar dan bekerja (magang) di Jepang. Inisiatif ini tidak hanya ditujukan sebagai upaya peningkatan kompetensi dan daya saing sumber daya manusia Indonesia di kancah internasional, tetapi juga sebagai wujud nyata dari panggilan hati pendirinya untuk mengajar dan mengamalkan ilmu yang telah diperoleh.</p>
+                                <p>Selama menjalani pendidikan di Jepang, pendiri LPK Asta Karya juga aktif melakukan berbagai pekerjaan paruh waktu di berbagai sektor, seperti toko serba ada, restoran, dan pabrik. Pengalaman tersebut memberikan pemahaman langsung mengenai etos kerja, tata krama, dan budaya kerja masyarakat Jepang yang dikenal dengan kedisiplinan tinggi, ketepatan waktu, serta semangat kerja yang total.</p>
+                                <p>Nilai-nilai positif inilah yang ingin ditanamkan kepada para pemuda Indonesia dengan memfasilitasi program magang di perusahaan-perusahaan di Jepang. Harapannya, para peserta tidak hanya memperoleh keterampilan teknis, namun juga menyerap nilai-nilai profesionalisme, pola pikir maju, dan etika kerja yang baik untuk kemudian diterapkan di tanah air.</p>
+                        </article>
+                        <article class="story-card">
+                                <h3 class="story-card-title">日本語</h3>
+                                <p>アスタ・カルヤは、2016年12月に設立された送出機関であり、インドネシア・ジャカルタ特別州の南ジャカルタ市に本部を構えています。創設者は日本語を専攻し、静岡県の日本語学校を卒業した経験を持つ教育者です。</p>
+                                <p>創設者は日本滞在中、コンビニエンスストア、レストラン、工場など様々な分野での就労経験を通じ、日本社会の高い規律、時間厳守、そして全力で取り組む労働文化を体験しました。こうして得た価値観をインドネシアの若者へ共有すべく、実践的な研修と人材育成を使命としています。</p>
+                                <p>日本での学びと労働の機会を提供することで、技術だけでなくプロフェッショナリズム、先進的な思考、労働倫理を習得できるよう支援しています。修了生が帰国後もこれらの価値を活かし、国内の発展に貢献することを目指しています。</p>
+                        </article>
+                        <article class="story-card">
+                                <h3 class="story-card-title">English</h3>
+                                <p>Asta Karya Training Institute (LPK Asta Karya) is an officially accredited Sending Organization established in December 2016 and headquartered in Tebet, South Jakarta, under PT. Ladang Berdikari Indonesia. Founded by an alumnus specializing in Japanese language studies and a graduate of a Nihongo Gakkō in Shizuoka Prefecture, Japan, the institute embodies a passion for education and service.</p>
+                                <p>The institute was created to offer Indonesian youth firsthand exposure to studying and interning in Japan. This initiative enhances global competitiveness while reflecting the founder’s calling to share knowledge for the advancement of the nation.</p>
+                                <p>Having undertaken diverse part-time roles across convenience stores, restaurants, and factories, the founder experienced Japan’s disciplined, punctual, and wholehearted work ethic. These values are passed on through internship facilitation, enabling participants to absorb professionalism, progressive mindsets, and exemplary ethics that benefit Indonesia upon their return.</p>
+                        </article>
+                </div>
+        </div>
+</section>
+
+<section id="vision" class="section section-muted">
+        <div class="container">
+                <div class="section-heading text-center">
+                        <span class="section-eyebrow">Visi &amp; Misi</span>
+                        <h2 class="section-title">Menjadi Jembatan Talenta Indonesia ke Dunia</h2>
+                        <p class="section-subtitle">Orientasi strategis lembaga dalam membentuk generasi profesional berdaya saing global.</p>
+                </div>
+                <div class="content-grid grid-3">
+                        <article class="vision-card">
+                                <h3 class="vision-card-title">Bahasa Indonesia</h3>
+                                <h4>Visi</h4>
+                                <p>Menjadi lembaga pelatihan kerja yang terpercaya, profesional, dan berstandar internasional dalam mempersiapkan tenaga kerja Indonesia yang kompeten, berkarakter, dan siap bersaing di dunia kerja global, khususnya di Jepang.</p>
+                                <p>LPK Asta Karya berkomitmen membentuk generasi muda Indonesia yang unggul, mandiri, dan berintegritas melalui program pelatihan terpadu serta pengalaman kerja langsung di Jepang.</p>
+                                <h4>Misi</h4>
+                                <ul>
+                                        <li>Memberdayakan SDM Indonesia melalui pengalaman hidup dan kerja di Jepang yang membentuk pola pikir positif dan etos kerja tinggi.</li>
+                                        <li>Meningkatkan kualitas pendidikan dan kompetensi tenaga kerja melalui pelatihan teknis dan pembelajaran Bahasa Jepang berorientasi industri.</li>
+                                        <li>Berperan dalam pengurangan angka pengangguran dengan mencetak tenaga kerja terlatih dan produktif.</li>
+                                        <li>Memperkuat hubungan internasional melalui partisipasi aktif dalam program pemagangan dan kerja sama bilateral Indonesia–Jepang.</li>
+                                </ul>
+                        </article>
+                        <article class="vision-card">
+                                <h3 class="vision-card-title">日本語</h3>
+                                <h4>ビジョン</h4>
+                                <p>インドネシアの人材を国際労働市場、特に日本で活躍できる能力・人格・競争力を備えた存在として育成し、信頼される国際基準の職業訓練機関となることを目指します。</p>
+                                <p>総合的な職業訓練と日本での実務経験を通じ、若者の潜在能力と国際産業界のニーズを結びつける架け橋になります。</p>
+                                <h4>ミッション</h4>
+                                <ul>
+                                        <li>日本での生活と労働を通じ、前向きな思考、高い労働倫理、国際的視野を育成します。</li>
+                                        <li>産業ニーズに即した日本語教育および技術訓練で将来の労働者の能力を向上させます。</li>
+                                        <li>熟練した即戦力人材を育成し、国内失業率の削減に貢献します。</li>
+                                        <li>二国間協力に参加し、国際的な意識と社会的責任を育みながら世界への貢献を実現します。</li>
+                                </ul>
+                        </article>
+                        <article class="vision-card">
+                                <h3 class="vision-card-title">English</h3>
+                                <h4>Vision</h4>
+                                <p>To become a trusted, professional, and internationally recognized training institution that prepares Indonesian workers to be competent, ethical, and globally competitive with a focus on opportunities in Japan.</p>
+                                <p>We emphasize both professional skills and character development to bridge Indonesian youth potential with international industry demands.</p>
+                                <h4>Mission</h4>
+                                <ul>
+                                        <li>Empower youth with life and work experiences in Japan that build strong work ethics and global perspectives.</li>
+                                        <li>Enhance competence through technical training and Japanese language education tailored to industry needs.</li>
+                                        <li>Contribute to reducing unemployment by producing skilled, work-ready, and productive talent.</li>
+                                        <li>Strengthen international collaboration via active participation in internship programs and bilateral cooperation.</li>
+                                </ul>
+                        </article>
+                </div>
+        </div>
+</section>
+
+<section id="organization" class="section">
+        <div class="container">
+                <div class="section-heading text-center">
+                        <span class="section-eyebrow">Struktur &amp; Data</span>
+                        <h2 class="section-title">Kolaborasi Terstruktur dan Transparan</h2>
+                        <p class="section-subtitle">Menampilkan struktur organisasi serta kesiapan data pemagangan siswa.</p>
+                </div>
+                <div class="organization-layout">
+                        <div class="organization-visual">
+                                <img src="/static/images/structure_organization.png" alt="Struktur Organisasi LPK Asta Karya" class="organization-image">
+                                <p class="organization-caption">Struktur Organisasi LPK Asta Karya</p>
+                        </div>
+                        <div class="organization-details">
+                                <div class="detail-card">
+                                        <h3 class="detail-card-title">Laporan Pengiriman Siswa</h3>
+                                        <p>Kami menyusun laporan penempatan siswa secara berkala, mencakup status keberangkatan, lokasi perusahaan mitra, serta progres adaptasi di Jepang.</p>
                                 </div>
-                                {{ if $home }}
-                                <a class="btn btn-outline" href="{{ $home.DocURL }}" target="_blank" rel="noopener">
-                                        <i class="fa fa-external-link"></i>
-                                        {{ $home.HeroButtonLabel }}
-                                </a>
-                                {{ end }}
+                                <div class="detail-card">
+                                        <h3 class="detail-card-title">Mapping Penempatan</h3>
+                                        <p>Data penempatan divisualisasikan melalui peta interaktif internal untuk memantau persebaran peserta di berbagai prefektur Jepang.</p>
+                                </div>
+                                <div class="detail-card">
+                                        <h3 class="detail-card-title">Infografis Data Siswa</h3>
+                                        <ul class="detail-list">
+                                                <li>Ringkasan jumlah siswa terkini berdasarkan angkatan.</li>
+                                                <li>Distribusi usia, jenis pekerjaan, dan gender peserta.</li>
+                                                <li>Dasbor statistik yang siap dikembangkan menjadi laporan publik.</li>
+                                        </ul>
+                                </div>
                         </div>
-                        {{ if $home }}
-                        <div class="preview-frame">
-                                <iframe src="{{ $home.DocEmbedURL }}" title="LPK Asta Karya Google Docs" loading="lazy" allowfullscreen></iframe>
+                </div>
+        </div>
+</section>
+
+<section id="training-center" class="section section-muted">
+        <div class="container">
+                <div class="section-heading text-center">
+                        <span class="section-eyebrow">Training Center</span>
+                        <h2 class="section-title">Lingkungan Belajar Modern di Kota Bandung</h2>
+                        <p class="section-subtitle">Fasilitas terintegrasi untuk mendukung kesiapan peserta sebelum berangkat ke Jepang.</p>
+                </div>
+                <div class="content-grid grid-2">
+                        <article class="content-card">
+                                <h3 class="content-card-title">Profil Fasilitas</h3>
+                                <p>LPK Asta Karya memiliki fasilitas Training Center yang berlokasi di Kota Bandung, Indonesia. Kota ini dikenal sebagai pusat pendidikan dengan iklim sejuk yang mendukung kenyamanan belajar.</p>
+                                <dl class="info-list compact">
+                                        <div><dt>Alamat</dt><dd>Jl. H. Ibrahim Adjie No.99, RT.03 RW.02, Kelurahan Cijawura, Kecamatan Buah Batu, Kota Bandung, Indonesia 40287</dd></div>
+                                        <div><dt>Kapasitas</dt><dd>100 peserta pelatihan</dd></div>
+                                </dl>
+                                <h4 class="content-card-subtitle">Fasilitas Utama</h4>
+                                <ul class="tag-list">
+                                        <li>Asrama</li>
+                                        <li>Dapur</li>
+                                        <li>Lapangan Olahraga</li>
+                                        <li>Laundry Room</li>
+                                        <li>Perpustakaan Kecil</li>
+                                        <li>Ruang Kesehatan</li>
+                                        <li>Multimedia</li>
+                                </ul>
+                        </article>
+                        <article class="content-card">
+                                <h3 class="content-card-title">Training Center in Japanese &amp; English</h3>
+                                <p><strong>日本語:</strong> バンドン市の研修センターは、静かな学習環境と快適な気候が特徴です。技術・言語・人格形成を総合的に育成する場として設計され、安全で質の高い事前研修を提供しています。</p>
+                                <p><strong>English:</strong> The Bandung Training Center delivers comprehensive preparation across technical, language, and character-building dimensions. It serves as the intensive staging ground before deployment to Japan, reflecting our commitment to a safe, result-oriented learning environment.</p>
+                                <h4 class="content-card-subtitle">Tim Pelatih</h4>
+                                <p>Pendiri LPK Asta Karya berpengalaman hidup dan studi di Jepang, memastikan proses rekrutmen pelatih mengedepankan kompetensi teknis, integritas, dan kemampuan memberi dampak positif bagi peserta.</p>
+                        </article>
+                </div>
+        </div>
+</section>
+
+<section id="training-team" class="section">
+        <div class="container">
+                <div class="section-heading text-center">
+                        <span class="section-eyebrow">Tim &amp; Trainee</span>
+                        <h2 class="section-title">Pelatih Berpengalaman, Peserta Berdaya Saing</h2>
+                        <p class="section-subtitle">Pendampingan intensif dari para profesional dengan pemahaman mendalam tentang budaya Jepang.</p>
+                </div>
+                <div class="content-grid grid-2">
+                        <article class="detail-card">
+                                <h3 class="detail-card-title">Tentang Tim Pendidikan dan Pelatihan</h3>
+                                <p>Berbekal pengalaman langsung di Jepang, tim pelatih Asta Karya memiliki integritas dan kepedulian tinggi terhadap perkembangan peserta. Proses seleksi pelatih menitikberatkan pada penguasaan bahasa, kompetensi teknis, pengalaman internasional, serta kemampuan memberikan pengaruh positif.</p>
+                                <p>Komitmen ini memastikan setiap peserta dibekali keterampilan, mentalitas, dan kesiapan optimal sebelum menghadapi masa pemagangan di Jepang.</p>
+                        </article>
+                        <article class="detail-card">
+                                <h3 class="detail-card-title">Keunggulan Trainee Kami</h3>
+                                <ul class="detail-list">
+                                        <li><strong>Kemampuan Bahasa Jepang Unggul:</strong> Trainee menguasai Bahasa Jepang dengan standar tinggi untuk memastikan transfer ilmu yang efektif.</li>
+                                        <li><strong>Pemahaman Budaya dan Disiplin:</strong> Pembekalan realistis tentang kehidupan, etika kerja, dan tata krama masyarakat Jepang.</li>
+                                        <li><strong>Pendekatan Humanis:</strong> Kedekatan emosional dan pendampingan menyeluruh untuk menjaga kesehatan mental siswa selama pemagangan.</li>
+                                </ul>
+                        </article>
+                </div>
+        </div>
+</section>
+
+<section id="curriculum" class="section section-muted">
+        <div class="container">
+                <div class="section-heading text-center">
+                        <span class="section-eyebrow">Kurikulum</span>
+                        <h2 class="section-title">Rangkaian Pembelajaran Terstruktur</h2>
+                        <p class="section-subtitle">Menggabungkan penguasaan bahasa, pemahaman budaya, dan kompetensi teknis.</p>
+                </div>
+                <div class="content-grid grid-3">
+                        <article class="module-card">
+                                <h3 class="module-card-title">Materi Dasar / Foundation</h3>
+                                <ul>
+                                        <li>Pelatihan Bahasa Jepang intensif.</li>
+                                        <li>Pengenalan pola hidup dan budaya masyarakat Jepang.</li>
+                                        <li>Latihan fisik terstruktur.</li>
+                                        <li>Survival life in Japan untuk adaptasi awal.</li>
+                                </ul>
+                        </article>
+                        <article class="module-card">
+                                <h3 class="module-card-title">Materi Inti / Core</h3>
+                                <ul>
+                                        <li>Pemahaman budaya kerja Jepang dan sistem operasional perusahaan.</li>
+                                        <li>Penanaman kedisiplinan, tanggung jawab, dan ketepatan waktu.</li>
+                                        <li>Penguatan kerja sama tim dan komunikasi profesional.</li>
+                                </ul>
+                        </article>
+                        <article class="module-card">
+                                <h3 class="module-card-title">Materi Khusus / Specialized</h3>
+                                <ul>
+                                        <li>Pelatihan keterampilan teknis sesuai bidang penempatan.</li>
+                                        <li>Penyesuaian kurikulum dengan industri mitra.</li>
+                                        <li>Simulasi kerja untuk kesiapan di perusahaan Jepang.</li>
+                                </ul>
+                        </article>
+                </div>
+                <div class="content-grid grid-3 curriculum-more">
+                        <article class="module-card">
+                                <h3 class="module-card-title">研修カリキュラム（日本語）</h3>
+                                <p>座学と実践演習を組み合わせ、基礎科目・核心科目・専門科目の3本柱で構成。現地適応、日本の職場文化理解、業種別専門技術の習得を目指します。</p>
+                        </article>
+                        <article class="module-card">
+                                <h3 class="module-card-title">Program Advantages</h3>
+                                <ul>
+                                        <li><strong>Peningkatan Kualitas Hidup:</strong> Transfer keterampilan dan pengetahuan sebagai bekal karier jangka panjang.</li>
+                                        <li><strong>Kontribusi Industri:</strong> Mendukung peningkatan kontrol kualitas, kedisiplinan, dan efisiensi biaya.</li>
+                                        <li><strong>Relasi Internasional:</strong> Mempererat kerja sama Indonesia–Jepang dan mendorong semangat globalisasi.</li>
+                                </ul>
+                        </article>
+                        <article class="module-card">
+                                <h3 class="module-card-title">English Summary</h3>
+                                <p>Our curriculum equips participants with language proficiency, workplace ethics, and specialized technical mastery. The holistic approach empowers graduates to become change agents and positive contributors in the global arena.</p>
+                        </article>
+                </div>
+        </div>
+</section>
+
+<section id="recruitment" class="section">
+        <div class="container">
+                <div class="section-heading text-center">
+                        <span class="section-eyebrow">Seleksi Peserta</span>
+                        <h2 class="section-title">Tahapan Rekrutmen Pemagangan ke Jepang</h2>
+                        <p class="section-subtitle">Proses seleksi ketat untuk memastikan kesiapan peserta dari aspek teknis, mental, dan fisik.</p>
+                </div>
+                <div class="timeline">
+                        <div class="timeline-item">
+                                <span class="timeline-step">01</span>
+                                <div class="timeline-content">
+                                        <h3>Medical Check-Up</h3>
+                                        <p>Pemeriksaan kesehatan menyeluruh untuk memastikan kandidat dalam kondisi prima dan siap menghadapi lingkungan kerja industri Jepang.</p>
+                                </div>
                         </div>
-                        <p class="preview-note">{{ $home.DocNote }}</p>
-                        {{ else }}
-                        <div class="preview-empty">
-                                <p>Konten dokumen belum tersedia. Perbarui berkas konfigurasi untuk menautkan dokumen resmi.</p>
+                        <div class="timeline-item">
+                                <span class="timeline-step">02</span>
+                                <div class="timeline-content">
+                                        <h3>Ujian Bahasa Jepang</h3>
+                                        <p>Meliputi wawancara percakapan langsung tanpa penerjemah serta ujian tertulis setara JLPT N5 atau N4 untuk sektor keperawatan.</p>
+                                </div>
                         </div>
-                        {{ end }}
+                        <div class="timeline-item">
+                                <span class="timeline-step">03</span>
+                                <div class="timeline-content">
+                                        <h3>Ujian Matematika Dasar</h3>
+                                        <p>Mengukur logika, ketelitian, dan kecepatan berhitung sebagai bekal kerja di industri dan manufaktur.</p>
+                                </div>
+                        </div>
+                        <div class="timeline-item">
+                                <span class="timeline-step">04</span>
+                                <div class="timeline-content">
+                                        <h3>IQ Test</h3>
+                                        <p>Menilai kemampuan intelektual dan adaptasi calon peserta terhadap sistem kerja di Jepang.</p>
+                                </div>
+                        </div>
+                        <div class="timeline-item">
+                                <span class="timeline-step">05</span>
+                                <div class="timeline-content">
+                                        <h3>Tes Fisik &amp; Kebugaran</h3>
+                                        <p>Memastikan daya tahan dan kebiasaan hidup sehat sehingga peserta siap menjalani kehidupan aktif selama pemagangan.</p>
+                                </div>
+                        </div>
+                </div>
+                <div class="recruitment-note">
+                        <div class="detail-card">
+                                <h3 class="detail-card-title">Kontribusi Program</h3>
+                                <ul class="detail-list">
+                                        <li><strong>生活の質向上:</strong> 技術と知識の習得が将来のキャリア形成に寄与します。</li>
+                                        <li><strong>産業界への貢献:</strong> 品質管理・規律・コスト効率の向上に繋がります。</li>
+                                        <li><strong>国際交流の強化:</strong> インドネシア–日本間の相互理解と協力を深化させます。</li>
+                                </ul>
+                                <p>Through this rigorous process, participants grow not only as professionals but also as positive contributors to society.</p>
+                        </div>
+                </div>
+        </div>
+</section>
+
+<section id="resources" class="section section-muted">
+        <div class="container">
+                <div class="section-heading text-center">
+                        <span class="section-eyebrow">Sumber Daya &amp; Media</span>
+                        <h2 class="section-title">Materi Pendukung dan Kanal Informasi</h2>
+                        <p class="section-subtitle">Akses ke dokumen penting, galeri kegiatan, dan konten multimedia Asta Karya.</p>
+                </div>
+                <div class="content-grid grid-3">
+                        <article class="resource-card">
+                                <h3 class="resource-card-title">Sample Handbook Siswa</h3>
+                                <p>Dokumen panduan berisi tata tertib, agenda pelatihan, dan persiapan keberangkatan. Hubungi tim kami untuk mendapatkan versi terbaru.</p>
+                                <a class="resource-link" href="mailto:astakarya.adm@gmail.com"><i class="fa fa-envelope"></i> Permintaan Handbook</a>
+                        </article>
+                        <article class="resource-card">
+                                <h3 class="resource-card-title">Galeri</h3>
+                                <p>Kumpulan dokumentasi kegiatan pelatihan dan keberangkatan peserta. Jelajahi momen-momen penting dalam perjalanan kami.</p>
+                                <a class="resource-link" href="/galery"><i class="fa fa-picture-o"></i> Lihat Galeri</a>
+                        </article>
+                        <article class="resource-card">
+                                <h3 class="resource-card-title">YouTube Asta Karya</h3>
+                                <p>Video testimoni, highlight pelatihan, dan informasi rekrutmen terbaru tersedia di kanal resmi kami.</p>
+                                <a class="resource-link" href="https://www.youtube.com" target="_blank" rel="noopener"><i class="fa fa-youtube-play"></i> Kunjungi Kanal</a>
+                        </article>
                 </div>
         </div>
 </section>

--- a/views/layout.html
+++ b/views/layout.html
@@ -36,9 +36,16 @@
                                 </div>
                                 <div class="collapse navbar-collapse" id="main-nav">
                                         <ul class="nav navbar-nav navbar-right">
-                                                <li><a href="#home" class="smoothScroll">{{ .Header.Home }}</a></li>
-                                                <li><a href="#highlights" class="smoothScroll">{{ .Header.Highlights }}</a></li>
-                                                <li><a href="#doc" class="smoothScroll">{{ .Header.Document }}</a></li>
+                                                <li><a href="#home" class="smoothScroll">Beranda</a></li>
+                                                <li><a href="#foreword" class="smoothScroll">Kata Pengantar</a></li>
+                                                <li><a href="#profile" class="smoothScroll">Profil</a></li>
+                                                <li><a href="#background" class="smoothScroll">Latar Belakang</a></li>
+                                                <li><a href="#vision" class="smoothScroll">Visi &amp; Misi</a></li>
+                                                <li><a href="#organization" class="smoothScroll">Organisasi</a></li>
+                                                <li><a href="#training-center" class="smoothScroll">Training Center</a></li>
+                                                <li><a href="#curriculum" class="smoothScroll">Kurikulum</a></li>
+                                                <li><a href="#recruitment" class="smoothScroll">Rekrutmen</a></li>
+                                                <li><a href="#resources" class="smoothScroll">Media</a></li>
                                                 <li><a href="/galery">{{ .Header.Galery }}</a></li>
                                                 <li class="dropdown nav-language">
                                                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">🌐</a>
@@ -63,7 +70,8 @@
                                 <div class="col-md-12">
                                         <p class="footer-text">© 2024 LPK Asta Karya. All rights reserved.</p>
                                         <div class="footer-links">
-                                                <a href="{{ if .Home }}{{ .Home.DocURL }}{{ else }}#{{ end }}" target="_blank" rel="noopener" class="footer-link">{{ .Header.Document }}</a>
+                                                <a href="#home" class="footer-link smoothScroll">Beranda</a>
+                                                <a href="#resources" class="footer-link smoothScroll">Media</a>
                                                 <a href="/galery" class="footer-link">{{ .Header.Galery }}</a>
                                         </div>
                                 </div>


### PR DESCRIPTION
## Summary
- rebuild the landing page into a single scrolling company profile that surfaces the provided hero messaging, foreword, organisation background, training centre, curriculum, recruitment process, and resource links in Indonesian, Japanese, and English
- refresh the global navigation and footer anchors to match the new sections and modernise the visual design with reusable card, grid, and timeline styles in the custom stylesheet

## Testing
- Not run (go test ./... hung during module execution)


------
https://chatgpt.com/codex/tasks/task_e_68da3588992883309ecc5280e321d8c8