### PR TITLE
Improve navigation dropdown layout

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -70,22 +70,36 @@
     color: #333333;
 }
 
-.navbar-nav > li.mega-menu .dropdown-menu.multi-column {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px 0;
-    padding: 16px 18px;
-    min-width: 360px;
+.navbar-nav > li.mega-menu .dropdown-menu {
+    padding: 20px 24px;
+    min-width: 380px;
 }
 
-.navbar-nav > li.mega-menu .dropdown-menu.multi-column > li {
-    width: 50%;
+.mega-menu-content .row {
+    margin-left: 0;
+    margin-right: 0;
 }
 
-.navbar-nav > li.mega-menu .dropdown-menu.multi-column > li > a {
-    padding: 8px 14px;
+.mega-menu-content [class^="col-"] {
+    padding-left: 10px;
+    padding-right: 10px;
+}
+
+.mega-menu-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.mega-menu-list li + li {
+    margin-top: 6px;
+}
+
+.mega-menu-list a {
     display: block;
-    white-space: normal;
+    padding: 8px 12px;
+    border-radius: 6px;
+    transition: background 0.2s ease, color 0.2s ease;
 }
 
 .navbar-nav > li.language-dropdown .dropdown-menu {
@@ -97,6 +111,13 @@
 .navbar-nav > li.dropdown .dropdown-menu > li > a:focus {
     background: #55acee;
     color: #ffffff;
+}
+
+.mega-menu-list a:hover,
+.mega-menu-list a:focus {
+    background: #55acee;
+    color: #ffffff;
+    text-decoration: none;
 }
 
 .highlight-card {

--- a/views/layout.html
+++ b/views/layout.html
@@ -42,37 +42,67 @@
                                                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                                                         {{ .Header.AboutMenu }} <span class="caret"></span>
                                                 </a>
-                                                <ul class="dropdown-menu multi-column">
-                                                        <li><a href="#foreword" class="smoothScroll">{{ .Header.Foreword }}</a></li>
-                                                        <li><a href="#profile" class="smoothScroll">{{ .Header.Profile }}</a></li>
-                                                        <li><a href="#background" class="smoothScroll">{{ .Header.Background }}</a></li>
-                                                        <li><a href="#vision" class="smoothScroll">{{ .Header.Vision }}</a></li>
-                                                        <li><a href="#organization" class="smoothScroll">{{ .Header.Structure }}</a></li>
-                                                        <li><a href="#report" class="smoothScroll">{{ .Header.Report }}</a></li>
-                                                </ul>
+                                                <div class="dropdown-menu mega-menu-content">
+                                                        <div class="row">
+                                                                <div class="col-sm-6">
+                                                                        <ul class="mega-menu-list">
+                                                                                <li><a href="#foreword" class="smoothScroll">{{ .Header.Foreword }}</a></li>
+                                                                                <li><a href="#profile" class="smoothScroll">{{ .Header.Profile }}</a></li>
+                                                                                <li><a href="#background" class="smoothScroll">{{ .Header.Background }}</a></li>
+                                                                        </ul>
+                                                                </div>
+                                                                <div class="col-sm-6">
+                                                                        <ul class="mega-menu-list">
+                                                                                <li><a href="#vision" class="smoothScroll">{{ .Header.Vision }}</a></li>
+                                                                                <li><a href="#organization" class="smoothScroll">{{ .Header.Structure }}</a></li>
+                                                                                <li><a href="#report" class="smoothScroll">{{ .Header.Report }}</a></li>
+                                                                        </ul>
+                                                                </div>
+                                                        </div>
+                                                </div>
                                         </li>
                                         <li class="dropdown mega-menu">
                                                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                                                         {{ .Header.ProgramMenu }} <span class="caret"></span>
                                                 </a>
-                                                <ul class="dropdown-menu multi-column">
-                                                        <li><a href="#training-center" class="smoothScroll">{{ .Header.Training }}</a></li>
-                                                        <li><a href="#educators" class="smoothScroll">{{ .Header.Educators }}</a></li>
-                                                        <li><a href="#trainee-strengths" class="smoothScroll">{{ .Header.Trainees }}</a></li>
-                                                        <li><a href="#team" class="smoothScroll">{{ .Header.Team }}</a></li>
-                                                        <li><a href="#curriculum" class="smoothScroll">{{ .Header.Curriculum }}</a></li>
-                                                        <li><a href="#handbook" class="smoothScroll">{{ .Header.Handbook }}</a></li>
-                                                </ul>
+                                                <div class="dropdown-menu mega-menu-content">
+                                                        <div class="row">
+                                                                <div class="col-sm-6">
+                                                                        <ul class="mega-menu-list">
+                                                                                <li><a href="#training-center" class="smoothScroll">{{ .Header.Training }}</a></li>
+                                                                                <li><a href="#educators" class="smoothScroll">{{ .Header.Educators }}</a></li>
+                                                                                <li><a href="#trainee-strengths" class="smoothScroll">{{ .Header.Trainees }}</a></li>
+                                                                        </ul>
+                                                                </div>
+                                                                <div class="col-sm-6">
+                                                                        <ul class="mega-menu-list">
+                                                                                <li><a href="#team" class="smoothScroll">{{ .Header.Team }}</a></li>
+                                                                                <li><a href="#curriculum" class="smoothScroll">{{ .Header.Curriculum }}</a></li>
+                                                                                <li><a href="#handbook" class="smoothScroll">{{ .Header.Handbook }}</a></li>
+                                                                        </ul>
+                                                                </div>
+                                                        </div>
+                                                </div>
                                         </li>
                                         <li class="dropdown mega-menu">
                                                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                                                         {{ .Header.InfoMenu }} <span class="caret"></span>
                                                 </a>
-                                                <ul class="dropdown-menu multi-column">
-                                                        <li><a href="#recruitment" class="smoothScroll">{{ .Header.Recruitment }}</a></li>
-                                                        <li><a href="#media" class="smoothScroll">{{ .Header.Media }}</a></li>
-                                                        <li><a href="/galery">{{ .Header.Galery }}</a></li>
-                                                </ul>
+                                                <div class="dropdown-menu mega-menu-content">
+                                                        <div class="row">
+                                                                <div class="col-sm-6">
+                                                                        <ul class="mega-menu-list">
+                                                                                <li><a href="#recruitment" class="smoothScroll">{{ .Header.Recruitment }}</a></li>
+                                                                                <li><a href="#media" class="smoothScroll">{{ .Header.Media }}</a></li>
+                                                                        </ul>
+                                                                </div>
+                                                                <div class="col-sm-6">
+                                                                        <ul class="mega-menu-list">
+                                                                                <li><a href="/galery">{{ .Header.Galery }}</a></li>
+                                                                        </ul>
+                                                                </div>
+                                                        </div>
+                                                </div>
                                         </li>
                                         <li class="dropdown language-dropdown">
                                                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
## Summary
- restructure the header dropdown menus into organized two-column mega menus
- refine the mega menu styling to improve spacing, hover states, and readability

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68da509ab8548330ba6d8c9ed9cb8a39